### PR TITLE
Add support for docker --net parameter

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -475,8 +475,11 @@ private[spark] class MesosClusterScheduler(
           val portmaps = submission.schedulerProperties
             .get("spark.mesos.executor.docker.portmaps")
             .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
+          val parameters = submission.schedulerProperties
+           .get("spark.mesos.executor.docker.property.net")
+           .map(MesosSchedulerBackendUtil.parseParameterSpec)
           MesosSchedulerBackendUtil.addDockerInfo(
-            container, image, volumes = volumes, portmaps = portmaps)
+            container, image, volumes = volumes, portmaps = portmaps, parameters = parameters))
           taskInfo.setContainer(container.build())
         }
         val queuedTasks = tasks.getOrElseUpdate(offer.offer.getId, new ArrayBuffer[TaskInfo])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support for Docker networking

As of Docker 1.9, there is the ability to create software defined networks.
